### PR TITLE
Fix filename pattern parsing

### DIFF
--- a/intellirename/main.py
+++ b/intellirename/main.py
@@ -65,21 +65,6 @@ from .utils import (
     rename_file,
 )
 
-# Filename parsing patterns
-FILENAME_PATTERNS = [
-    # "[Publisher] Author(s) - Title (Year, Publisher).pdf"
-    re.compile(
-        r"^\[.*?\]\s*(.+?)\s*-\s*(.+?)\s*\((\d{4}).*?\)\.(pdf|epub)$", re.IGNORECASE
-    ),
-    # "Author(s) - Title (Year).pdf"
-    re.compile(r"^(.+?)\s*-\s*(.+?)\s*\((\d{4}).*?\)\.(pdf|epub)$", re.IGNORECASE),
-    # "Title - Author(s) (Year).pdf"
-    re.compile(r"^(.+?)\s*-\s*(.+?)\s*\((\d{4}).*?\)\.(pdf|epub)$", re.IGNORECASE),
-    # "Title (Year).pdf"
-    re.compile(r"^(.+?)\s*\((\d{4}).*?\)\.(pdf|epub)$", re.IGNORECASE),
-    # "Author(s) - Title.pdf"
-    re.compile(r"^(.+?)\s*-\s*(.+?)\.(pdf|epub)$", re.IGNORECASE),
-]
 
 # Configure logging with rich
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- fix `extract_from_filename` so 'Title - Author (Year)' is parsed correctly
- remove unused duplicate filename pattern list from `main.py`

## Testing
- `python -m py_compile intellirename/metadata.py intellirename/main.py`
- `python -m pytest -q tests/test_intellirename.py` *(fails: No module named pytest)*