### PR TITLE
Add pytest tests optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dev = [
     "types-requests==2.*",
     "pytest==8.*",
 ]
+tests = [
+    "pytest==8.*",
+]
 
 [project.scripts]
 intellirename = "intellirename.main:cli_entry_point"

--- a/uv.lock
+++ b/uv.lock
@@ -384,6 +384,9 @@ dev = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
 ]
+tests = [
+    { name = "pytest" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -396,6 +399,7 @@ requires-dist = [
     { name = "pypdf2", specifier = "==3.*" },
     { name = "pytest", specifier = "==8.*" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.*" },
+    { name = "pytest", marker = "extra == 'tests'", specifier = "==8.*" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = "==5.*" },
     { name = "python-dateutil", specifier = "==2.*" },


### PR DESCRIPTION
## Summary
- include a `tests` optional dependency in `pyproject.toml`
- update `uv.lock` with corresponding `tests` extra

## Testing
- `uv run mypy intellirename tests` *(fails: No route to host)*
- `uv run pytest` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_68388a57123883318e23d4ff7db8c313