### PR TITLE
Add collision test for rename_file

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import tempfile
+from pathlib import Path
+
+from intellirename.utils import rename_file
+
+
+def test_rename_file_collision() -> None:
+    """Files with the same target name get suffixed on rename."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        first = Path(temp_dir) / "first.txt"
+        second = Path(temp_dir) / "second.txt"
+        first.write_text("one")
+        second.write_text("two")
+
+        rename_file(str(first), "target.txt")
+        msg = rename_file(str(second), "target.txt")
+
+        expected_path = Path(temp_dir) / "target_1.txt"
+        assert expected_path.exists()
+        assert "target_1.txt" in msg


### PR DESCRIPTION
## Summary
- add a test ensuring rename_file appends a suffix when the target already exists

## Testing
- `pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_682bfcd364fc8331a9c30d5a2949c14b